### PR TITLE
Add Dockerfile & Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:noble
+WORKDIR /app
+RUN apt update && \
+  apt install -y nodejs npm git && \
+  npm install --global yarn
+COPY . .
+RUN yarn
+CMD ["yarn", "build:run"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  app:
+    restart: unless-stopped
+    build: .
+    ports:
+      - 8080:5000


### PR DESCRIPTION
- add Dockerfile & Docker Compose for easy deploying
- it will listen on host port 8080
- it depends on repo directory, but COPY . . can be replaced with git clone

To start:
docker compose build
docker compose up -d